### PR TITLE
bug: mesh networking var not honoured

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Default: `{}`
 
 The following outputs are exported:
 
+### <a name="output_firewall_policies"></a> [firewall\_policies](#output\_firewall\_policies)
+
+Description: A curated output of the firewall policies created by this module.
+
 ### <a name="output_firewalls"></a> [firewalls](#output\_firewalls)
 
 Description: A curated output of the firewalls created by this module.

--- a/avm.tflint.override.hcl
+++ b/avm.tflint.override.hcl
@@ -1,8 +1,0 @@
-# Disable as this is a pattern module that creates multiple types of resources exposed through other outputs
-rule "required_output_rmfr7" {
-  enabled = false
-}
-
-rule "provider_azurerm_version" {
-  enabled = false
-}

--- a/avm.tflint_example.override.hcl
+++ b/avm.tflint_example.override.hcl
@@ -1,3 +1,0 @@
-rule "provider_azurerm_version" {
-  enabled = false
-}

--- a/examples/azure_landing_zone_firewall/README.md
+++ b/examples/azure_landing_zone_firewall/README.md
@@ -347,6 +347,26 @@ module "vm_spoke2" {
 output "virtual_networks" {
   value = module.hub_mesh.virtual_networks
 }
+
+output "firewall" {
+  value = module.hub_mesh.firewall
+}
+
+output "firewall_policies" {
+  value = module.hub_mesh.firewall_policies
+}
+
+output "route_tables_firewall" {
+  value = module.hub_mesh.hub_route_tables_firewall
+}
+
+output "route_tables_user_subnets" {
+  value = module.hub_mesh.hub_route_tables_user_subnets
+}
+
+output "resource_groups" {
+  value = module.hub_mesh.resource_groups
+}
 ```
 
 <!-- markdownlint-disable MD033 -->
@@ -387,6 +407,26 @@ No optional inputs.
 ## Outputs
 
 The following outputs are exported:
+
+### <a name="output_firewall"></a> [firewall](#output\_firewall)
+
+Description: n/a
+
+### <a name="output_firewall_policies"></a> [firewall\_policies](#output\_firewall\_policies)
+
+Description: n/a
+
+### <a name="output_resource_groups"></a> [resource\_groups](#output\_resource\_groups)
+
+Description: n/a
+
+### <a name="output_route_tables_firewall"></a> [route\_tables\_firewall](#output\_route\_tables\_firewall)
+
+Description: n/a
+
+### <a name="output_route_tables_user_subnets"></a> [route\_tables\_user\_subnets](#output\_route\_tables\_user\_subnets)
+
+Description: n/a
 
 ### <a name="output_virtual_networks"></a> [virtual\_networks](#output\_virtual\_networks)
 

--- a/examples/azure_landing_zone_firewall/README.md
+++ b/examples/azure_landing_zone_firewall/README.md
@@ -349,7 +349,7 @@ output "virtual_networks" {
 }
 
 output "firewall" {
-  value = module.hub_mesh.firewall
+  value = module.hub_mesh.firewalls
 }
 
 output "firewall_policies" {

--- a/examples/azure_landing_zone_firewall/main.tf
+++ b/examples/azure_landing_zone_firewall/main.tf
@@ -343,7 +343,7 @@ output "virtual_networks" {
 }
 
 output "firewall" {
-  value = module.hub_mesh.firewall
+  value = module.hub_mesh.firewalls
 }
 
 output "firewall_policies" {

--- a/examples/azure_landing_zone_firewall/main.tf
+++ b/examples/azure_landing_zone_firewall/main.tf
@@ -341,3 +341,23 @@ module "vm_spoke2" {
 output "virtual_networks" {
   value = module.hub_mesh.virtual_networks
 }
+
+output "firewall" {
+  value = module.hub_mesh.firewall
+}
+
+output "firewall_policies" {
+  value = module.hub_mesh.firewall_policies
+}
+
+output "route_tables_firewall" {
+  value = module.hub_mesh.hub_route_tables_firewall
+}
+
+output "route_tables_user_subnets" {
+  value = module.hub_mesh.hub_route_tables_user_subnets
+}
+
+output "resource_groups" {
+  value = module.hub_mesh.resource_groups
+}

--- a/locals.peering.tf
+++ b/locals.peering.tf
@@ -13,7 +13,7 @@ locals {
       allow_forwarded_traffic      = true
       allow_gateway_transit        = true
       use_remote_gateways          = false
-    } if key_from != key_to]
+    } if key_from != key_to && value_from.mesh_peering_enabled]
     ]) : peering.composite_key => peering
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,13 @@
+output "firewall_policies" {
+  description = "A curated output of the firewall policies created by this module."
+  value = {
+    for vnet_name, fw_policy in module.fw_policies : vnet_name => {
+      id   = fw_policy.resource_id
+      name = fw_policy.resource.name
+    }
+  }
+}
+
 output "firewalls" {
   description = "A curated output of the firewalls created by this module."
   value = {
@@ -25,7 +35,7 @@ output "hub_route_tables_user_subnets" {
   description = "A curated output of the route tables created by this module."
   value = {
     for vnet_name, rt in module.hub_routing_user_subnets : vnet_name => {
-      name = rt.name
+      name = rt.resource.name
       id   = rt.resource_id
     }
   }


### PR DESCRIPTION
## Description

* Honour the mesh networking variable
* Add firewall policies to the outputs

Fixes https://github.com/Azure/terraform-azurerm-avm-ptn-hubnetworking/issues/109

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
