### PR TITLE
feat: make management ip optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Description: A map of the hub virtual networks to create. The map key is an arbi
   - `subnet_address_prefix` - The IPv4 address prefix to use for the Azure Firewall subnet in CIDR format. Needs to be a part of the virtual network's address space.
   - `subnet_default_outbound_access_enabled` - (Optional) Should the default outbound access be enabled for the Azure Firewall subnet? Default `false`.
   - `firewall_policy_id` - (Optional) The resource id of the Azure Firewall Policy to associate with the Azure Firewall.
+  - `management_ip_enabled` - (Optional) Should the Azure Firewall management IP be enabled? Default `true`.
   - `management_subnet_address_prefix` - (Optional) The IPv4 address prefix to use for the Azure Firewall management subnet in CIDR format. Needs to be a part of the virtual network's address space.
   - `management_subnet_default_outbound_access_enabled` - (Optional) Should the default outbound access be enabled for the Azure Firewall management subnet? Default `false`.
   - `name` - (Optional) The name of the firewall resource. If not specified will use `afw-{vnetname}`.
@@ -285,6 +286,7 @@ map(object({
       subnet_address_prefix                             = string
       subnet_default_outbound_access_enabled            = optional(bool, false)
       firewall_policy_id                                = optional(string, null)
+      management_ip_enabled                             = optional(bool, true)
       management_subnet_address_prefix                  = optional(string, null)
       management_subnet_default_outbound_access_enabled = optional(bool, false)
       name                                              = optional(string)

--- a/README.md
+++ b/README.md
@@ -419,6 +419,10 @@ Description: A curated output of the resource groups created by this module.
 
 Description: The resource IDs of the hub virtual networks.
 
+### <a name="output_test"></a> [test](#output\_test)
+
+Description: n/a
+
 ### <a name="output_virtual_networks"></a> [virtual\_networks](#output\_virtual\_networks)
 
 Description: A curated output of the virtual networks created by this module.

--- a/examples/azure_landing_zone_firewall/README.md
+++ b/examples/azure_landing_zone_firewall/README.md
@@ -38,7 +38,7 @@ provider "azurerm" {
 locals {
   regions = {
     primary   = "eastus2"
-    secondary = "westus2"
+    secondary = "swedencentral"
   }
 }
 
@@ -405,11 +405,11 @@ No optional inputs.
 
 The following outputs are exported:
 
-### <a name="output_firewall"></a> [firewall](#output\_firewall)
+### <a name="output_firewall_policies"></a> [firewall\_policies](#output\_firewall\_policies)
 
 Description: n/a
 
-### <a name="output_firewall_policies"></a> [firewall\_policies](#output\_firewall\_policies)
+### <a name="output_firewalls"></a> [firewalls](#output\_firewalls)
 
 Description: n/a
 

--- a/examples/azure_landing_zone_firewall/README.md
+++ b/examples/azure_landing_zone_firewall/README.md
@@ -38,7 +38,7 @@ provider "azurerm" {
 locals {
   regions = {
     primary   = "eastus2"
-    secondary = "eastus2"
+    secondary = "westus2"
   }
 }
 

--- a/examples/azure_landing_zone_firewall/README.md
+++ b/examples/azure_landing_zone_firewall/README.md
@@ -81,6 +81,7 @@ module "hub_mesh" {
             zones = ["1", "2", "3"]
           }
         }
+        management_ip_enabled = true
         management_ip_configuration = {
           name = "pip-fw-hub-primary-mgmt"
           public_ip_config = {
@@ -147,6 +148,7 @@ module "hub_mesh" {
             zones = ["1", "2", "3"]
           }
         }
+        management_ip_enabled = false
         management_ip_configuration = {
           public_ip_config = {
             name  = "pip-fw-mgmt-hub-secondary"

--- a/examples/azure_landing_zone_firewall/main.tf
+++ b/examples/azure_landing_zone_firewall/main.tf
@@ -32,7 +32,7 @@ provider "azurerm" {
 locals {
   regions = {
     primary   = "eastus2"
-    secondary = "westus2"
+    secondary = "swedencentral"
   }
 }
 

--- a/examples/azure_landing_zone_firewall/main.tf
+++ b/examples/azure_landing_zone_firewall/main.tf
@@ -75,6 +75,7 @@ module "hub_mesh" {
             zones = ["1", "2", "3"]
           }
         }
+        management_ip_enabled = true
         management_ip_configuration = {
           name = "pip-fw-hub-primary-mgmt"
           public_ip_config = {
@@ -141,6 +142,7 @@ module "hub_mesh" {
             zones = ["1", "2", "3"]
           }
         }
+        management_ip_enabled = false
         management_ip_configuration = {
           public_ip_config = {
             name  = "pip-fw-mgmt-hub-secondary"

--- a/examples/azure_landing_zone_firewall/main.tf
+++ b/examples/azure_landing_zone_firewall/main.tf
@@ -32,7 +32,7 @@ provider "azurerm" {
 locals {
   regions = {
     primary   = "eastus2"
-    secondary = "eastus2"
+    secondary = "westus2"
   }
 }
 

--- a/examples/azure_landing_zone_firewall/outputs.tf
+++ b/examples/azure_landing_zone_firewall/outputs.tf
@@ -1,9 +1,9 @@
-output "firewall" {
-  value = module.hub_mesh.firewalls
-}
-
 output "firewall_policies" {
   value = module.hub_mesh.firewall_policies
+}
+
+output "firewalls" {
+  value = module.hub_mesh.firewalls
 }
 
 output "resource_groups" {

--- a/locals.firewall.tf
+++ b/locals.firewall.tf
@@ -4,6 +4,7 @@ locals {
   }
 }
 
+
 locals {
   firewalls = {
     for vnet_name, vnet in var.hub_virtual_networks : vnet_name => {

--- a/locals.firewall.tf
+++ b/locals.firewall.tf
@@ -19,7 +19,7 @@ locals {
         name = try(coalesce(vnet.firewall.default_ip_configuration.name, "default"), "default")
       }
       management_ip_enabled = try(vnet.firewall.management_ip_enabled, true)
-      management_ip_configuration = try(vnet.firewall.management_ip_enabled, true) ? {} : {
+      management_ip_configuration = {
         name = try(coalesce(vnet.firewall.management_ip_configuration.name, "defaultMgmt"), "defaultMgmt")
       }
       zones = vnet.firewall.zones

--- a/locals.firewall.tf
+++ b/locals.firewall.tf
@@ -4,7 +4,6 @@ locals {
   }
 }
 
-
 locals {
   firewalls = {
     for vnet_name, vnet in var.hub_virtual_networks : vnet_name => {

--- a/locals.firewall.tf
+++ b/locals.firewall.tf
@@ -18,7 +18,8 @@ locals {
       default_ip_configuration = {
         name = try(coalesce(vnet.firewall.default_ip_configuration.name, "default"), "default")
       }
-      management_ip_configuration = {
+      management_ip_enabled = try(vnet.firewall.management_ip_enabled, true)
+      management_ip_configuration = try(vnet.firewall.management_ip_enabled, true) ? {} : {
         name = try(coalesce(vnet.firewall.management_ip_configuration.name, "defaultMgmt"), "defaultMgmt")
       }
       zones = vnet.firewall.zones
@@ -44,7 +45,7 @@ locals {
       sku_tier            = try(vnet.firewall.management_ip_configuration.public_ip_config.sku_tier, "Regional")
       tags                = vnet.firewall.tags
       zones               = try(vnet.firewall.management_ip_configuration.public_ip_config.zones, null)
-    } if vnet.firewall != null
+    } if vnet.firewall != null && try(vnet.firewall.management_ip_enabled, true)
   }
   fw_policies = {
     for vnet_name, vnet in var.hub_virtual_networks : vnet_name => {

--- a/locals.routing.tf
+++ b/locals.routing.tf
@@ -42,7 +42,7 @@ locals {
             resource_group_name    = try(v_src.resource_group_name, azurerm_resource_group.rg[k_src].name)
           } if k_src != k_dst && v_dst.mesh_peering_enabled && can(v_dst.routing_address_space[0]) && local.create_route_tables_firewall[k_dst]
         ]
-      ] if v_src.mesh_peering_enabled
+      ] if v_src.mesh_peering_enabled && local.create_route_tables_firewall[k_src]
     ]) : route.key => route
   }
   route_table_entries_firewall = {
@@ -88,7 +88,7 @@ locals {
             resource_group_name    = try(v_src.resource_group_name, azurerm_resource_group.rg[k_src].name)
           } if v_dst.mesh_peering_enabled && can(v_dst.routing_address_space[0]) && local.create_route_tables_user_subnets[k_dst]
         ]
-      ] if v_src.mesh_peering_enabled
+      ] if v_src.mesh_peering_enabled && local.create_route_tables_user_subnets[k_src]
     ]) : route.key => route
   }
   route_table_entries_user_subnet = {

--- a/locals.subnet.tf
+++ b/locals.subnet.tf
@@ -18,7 +18,7 @@ locals {
       route_table                                   = null
       default_outbound_access_enabled               = v.firewall.management_subnet_default_outbound_access_enabled
     }
-    if v.firewall != null
+    if v.firewall != null && try(v.firewall.management_subnet_enabled, true)
   }
   firewall_route_table_ids = {
     # NOTE: For the destroy, you cannot delete the default route before removing the route table from the AzureFirewallSubnet.

--- a/locals.subnet.tf
+++ b/locals.subnet.tf
@@ -18,7 +18,7 @@ locals {
       route_table                                   = null
       default_outbound_access_enabled               = v.firewall.management_subnet_default_outbound_access_enabled
     }
-    if v.firewall != null && try(v.firewall.management_subnet_enabled, true)
+    if v.firewall != null && try(v.firewall.management_ip_enabled, true)
   }
   firewall_route_table_ids = {
     # NOTE: For the destroy, you cannot delete the default route before removing the route table from the AzureFirewallSubnet.

--- a/main.firewall.tf
+++ b/main.firewall.tf
@@ -14,7 +14,7 @@ module "hub_firewalls" {
     public_ip_address_id = module.fw_default_ips[each.key].public_ip_id
     subnet_id            = module.hub_virtual_network_subnets["${each.key}-${local.firewall_subnet_name}"].resource_id
   }]
-  firewall_management_ip_configuration = {
+  firewall_management_ip_configuration = each.value.management_ip_enabled ? null : {
     name                 = each.value.management_ip_configuration.name
     public_ip_address_id = module.fw_management_ips[each.key].public_ip_id
     subnet_id            = try(module.hub_virtual_network_subnets["${each.key}-${local.firewall_management_subnet_name}"].resource_id, null)

--- a/main.firewall.tf
+++ b/main.firewall.tf
@@ -16,7 +16,7 @@ module "hub_firewalls" {
   }]
   firewall_management_ip_configuration = each.value.management_ip_enabled ? null : {
     name                 = each.value.management_ip_configuration.name
-    public_ip_address_id = module.fw_management_ips[each.key].public_ip_id
+    public_ip_address_id = try(module.fw_management_ips[each.key].public_ip_id, null)
     subnet_id            = try(module.hub_virtual_network_subnets["${each.key}-${local.firewall_management_subnet_name}"].resource_id, null)
   }
   firewall_policy_id         = each.value.firewall_policy_id

--- a/main.firewall.tf
+++ b/main.firewall.tf
@@ -14,11 +14,11 @@ module "hub_firewalls" {
     public_ip_address_id = module.fw_default_ips[each.key].public_ip_id
     subnet_id            = module.hub_virtual_network_subnets["${each.key}-${local.firewall_subnet_name}"].resource_id
   }]
-  firewall_management_ip_configuration = each.value.management_ip_enabled ? null : {
-    name                 = each.value.management_ip_configuration.name
+  firewall_management_ip_configuration = each.value.management_ip_enabled ? {
+    name                 = try(each.value.management_ip_configuration.name, null)
     public_ip_address_id = try(module.fw_management_ips[each.key].public_ip_id, null)
     subnet_id            = try(module.hub_virtual_network_subnets["${each.key}-${local.firewall_management_subnet_name}"].resource_id, null)
-  }
+  } : null
   firewall_policy_id         = each.value.firewall_policy_id
   firewall_private_ip_ranges = each.value.private_ip_ranges
   firewall_zones             = each.value.zones

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,6 +62,10 @@ output "resource_id" {
   value       = { for key, value in module.hub_virtual_networks : key => value.resource_id }
 }
 
+output "test" {
+  value = local.firewalls
+}
+
 output "virtual_networks" {
   description = "A curated output of the virtual networks created by this module."
   value = {

--- a/variables.tf
+++ b/variables.tf
@@ -88,6 +88,7 @@ variable "hub_virtual_networks" {
       subnet_address_prefix                             = string
       subnet_default_outbound_access_enabled            = optional(bool, false)
       firewall_policy_id                                = optional(string, null)
+      management_ip_enabled                             = optional(bool, true)
       management_subnet_address_prefix                  = optional(string, null)
       management_subnet_default_outbound_access_enabled = optional(bool, false)
       name                                              = optional(string)
@@ -253,6 +254,7 @@ A map of the hub virtual networks to create. The map key is an arbitrary value t
   - `subnet_address_prefix` - The IPv4 address prefix to use for the Azure Firewall subnet in CIDR format. Needs to be a part of the virtual network's address space.
   - `subnet_default_outbound_access_enabled` - (Optional) Should the default outbound access be enabled for the Azure Firewall subnet? Default `false`.
   - `firewall_policy_id` - (Optional) The resource id of the Azure Firewall Policy to associate with the Azure Firewall.
+  - `management_ip_enabled` - (Optional) Should the Azure Firewall management IP be enabled? Default `true`.
   - `management_subnet_address_prefix` - (Optional) The IPv4 address prefix to use for the Azure Firewall management subnet in CIDR format. Needs to be a part of the virtual network's address space.
   - `management_subnet_default_outbound_access_enabled` - (Optional) Should the default outbound access be enabled for the Azure Firewall management subnet? Default `false`.
   - `name` - (Optional) The name of the firewall resource. If not specified will use `afw-{vnetname}`.


### PR DESCRIPTION
## Description

It turns out a management ip cannot be added to an existing firewall, so we need an option to turn it off for backwards compatibility.

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
