### PR TITLE
fix: add retries on peering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# AVM core team owns key files
-.github/policies/ @Azure/avm-core-team-technical-terraform
 .github/CODEOWNERS @Azure/avm-core-team-technical-terraform

--- a/README.md
+++ b/README.md
@@ -492,19 +492,19 @@ Version: 0.3.1
 
 Source: Azure/avm-res-network-virtualnetwork/azurerm//modules/peering
 
-Version: 0.7.1
+Version: 0.9.0
 
 ### <a name="module_hub_virtual_network_subnets"></a> [hub\_virtual\_network\_subnets](#module\_hub\_virtual\_network\_subnets)
 
 Source: Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet
 
-Version: 0.7.1
+Version: 0.9.0
 
 ### <a name="module_hub_virtual_networks"></a> [hub\_virtual\_networks](#module\_hub\_virtual\_networks)
 
 Source: Azure/avm-res-network-virtualnetwork/azurerm
 
-Version: 0.7.1
+Version: 0.9.0
 
 <!-- markdownlint-disable-next-line MD041 -->
 ## Data Collection

--- a/avm
+++ b/avm
@@ -6,7 +6,8 @@ usage () {
 
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-docker}
 
-if [ ! "$(command -v "$CONTAINER_RUNTIME")" ]; then
+
+if [ ! "$(command -v "$CONTAINER_RUNTIME")" ] && [ -z "$AVM_IN_CONTAINER" ]; then
     echo "Error: $CONTAINER_RUNTIME is not installed. Please install $CONTAINER_RUNTIME first."
     exit 1
 fi
@@ -20,6 +21,13 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+# Set pull option based on AVM_NO_CONTAINER_PULL
+if [ -z "$AVM_NO_CONTAINER_PULL" ]; then
+  PULL_OPTION="--pull always"
+else
+  PULL_OPTION=""
+fi
+
 # Check if AZURE_CONFIG_DIR is set, if not, set it to ~/.azure
 if [ -z "$AZURE_CONFIG_DIR" ]; then
   AZURE_CONFIG_DIR="$HOME/.azure"
@@ -28,7 +36,7 @@ fi
 # Check if we are running in a container
 # If we are then just run make directly
 if [ -z "$AVM_IN_CONTAINER" ]; then
-  $CONTAINER_RUNTIME run --pull always --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
+  $CONTAINER_RUNTIME run $PULL_OPTION --user "$(id -u):$(id -g)" --rm -v "$(pwd)":/src -w /src -v $AZURE_CONFIG_DIR:/azureconfig -e AZURE_CONFIG_DIR=/azureconfig -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e ARM_SUBSCRIPTION_ID -e ARM_TENANT_ID -e ARM_CLIENT_ID -e GITHUB_REPOSITORY_OWNER $AVM_IMAGE make "$1"
 else
   make "$1"
 fi

--- a/main.virtual.network.tf
+++ b/main.virtual.network.tf
@@ -1,6 +1,6 @@
 module "hub_virtual_networks" {
   source   = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version  = "0.7.1"
+  version  = "0.9.0"
   for_each = var.hub_virtual_networks
 
   address_space       = each.value.address_space
@@ -21,7 +21,7 @@ module "hub_virtual_networks" {
 
 module "hub_virtual_network_subnets" {
   source   = "Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet"
-  version  = "0.7.1"
+  version  = "0.9.0"
   for_each = local.subnets
 
   address_prefixes                              = each.value.address_prefixes
@@ -42,7 +42,7 @@ module "hub_virtual_network_subnets" {
 
 module "hub_virtual_network_peering" {
   source   = "Azure/avm-res-network-virtualnetwork/azurerm//modules/peering"
-  version  = "0.7.1"
+  version  = "0.9.0"
   for_each = local.peerings
 
   allow_forwarded_traffic      = each.value.allow_forwarded_traffic


### PR DESCRIPTION
## Description

Update the version of the vnet module to allow reties on peering when the vnet is in an updating state

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
